### PR TITLE
Feature/like functionality

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,6 @@ displayShows()
       const { id } = element.dataset;
       element.addEventListener('click', () => {
         updateLikes(id, element);
-      });
+      }, { once: true });
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -2,4 +2,13 @@ import './style.css';
 
 import displayShows from './modules/dom-manipulation.js';
 
-displayShows();
+displayShows()
+  .then(() => {
+    const likeBtns = document.querySelectorAll('.like-wrapper');
+    likeBtns.forEach((element) => {
+      const { id } = element.dataset;
+      element.addEventListener('click', (e) => {
+        console.log(element.lastElementChild.textContent)
+      })
+    })
+  })

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,14 @@
 import './style.css';
 
-import displayShows from './modules/dom-manipulation.js';
+import { displayShows, updateLikes } from './modules/dom-manipulation.js';
 
 displayShows()
   .then(() => {
     const likeBtns = document.querySelectorAll('.like-wrapper');
     likeBtns.forEach((element) => {
       const { id } = element.dataset;
-      element.addEventListener('click', (e) => {
-        console.log(element.lastElementChild.textContent)
-      })
-    })
-  })
+      element.addEventListener('click', () => {
+        updateLikes(id, element);
+      });
+    });
+  });

--- a/src/modules/api-requests.js
+++ b/src/modules/api-requests.js
@@ -1,8 +1,14 @@
-const url = 'https://api.tvmaze.com/search/shows?q=';
+const showsUrl = 'https://api.tvmaze.com/search/shows?q=';
+const likesUrl = 'https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/DxgcbWZ6MHoTsGdusWNs/likes/';
 
 const getShows = async (letter) => {
-  const result = await fetch(`${url}${letter}`).then((response) => response.json());
+  const result = await fetch(`${showsUrl}${letter}`).then((response) => response.json());
   return result;
 };
 
-export default getShows;
+const getLikes = async () => {
+  const result = await fetch(`${likesUrl}`).then((response) => response.json());
+  return result;
+};
+
+export { getShows, getLikes };

--- a/src/modules/api-requests.js
+++ b/src/modules/api-requests.js
@@ -11,4 +11,15 @@ const getLikes = async () => {
   return result;
 };
 
-export { getShows, getLikes };
+const postLike = async (id) => {
+  const result = await fetch(likesUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ item_id: id }),
+  });
+  return result;
+};
+
+export { getShows, getLikes, postLike };

--- a/src/modules/dom-manipulation.js
+++ b/src/modules/dom-manipulation.js
@@ -1,12 +1,18 @@
-import getShows from './api-requests.js';
+import { getShows, getLikes } from './api-requests.js';
 
 const displayShows = async () => {
   const data = await getShows('c');
+  const likes = await getLikes();
   const fragment = new DocumentFragment();
   const container = document.querySelector('.cards-container');
   const parser = new DOMParser();
   data.forEach((element, index) => {
     const { show } = element;
+    const item = likes.find((e) => e.item_id === show.id);
+    let likeCount = 0;
+    if (item) {
+      likeCount = item.likes;
+    }
     const cardStr = `<div class="col-12 col-md-4">
     <div class="card mb-3">
     <img src="${show.image.original}" class="card-img-top" alt="${show.name} image">
@@ -14,9 +20,9 @@ const displayShows = async () => {
       <div class="d-flex justify-content-between">
           <h5 class="card-title">${show.name}</h5>
           <div class="btn-wrapper d-flex">     
-        <div class="like-wrapper text-center me-3" data-index="${index}" role="button">          
+        <div class="like-wrapper text-center me-3" data-id="${show.id}" role="button">          
           <i class="fa-regular fa-heart fa-xl like"></i>
-          <p>2</p>
+          <p>${likeCount}</p>
         </div>      
         <div class="comments-wrapper text-center" data-index="${index}" role="button">          
         <i class="fa-regular fa-comment-dots fa-xl"></i>

--- a/src/modules/dom-manipulation.js
+++ b/src/modules/dom-manipulation.js
@@ -40,8 +40,15 @@ const displayShows = async () => {
 };
 
 const updateLikes = async (id, element) => {
-  let likeCount = element.lastElementChild.textContent;
-  
-}
+  let likeCount = parseInt(element.lastElementChild.textContent, 10);
+  const heart = element.firstElementChild;
+  const result = await postLike(parseInt(id, 10));
+  if (result) {
+    likeCount += 1;
+    element.lastElementChild.innerText = likeCount;
+    heart.classList.add('fa-solid');
+    element.classList.add('disabled');
+  }
+};
 
-export default displayShows;
+export { displayShows, updateLikes };

--- a/src/modules/dom-manipulation.js
+++ b/src/modules/dom-manipulation.js
@@ -1,4 +1,4 @@
-import { getShows, getLikes } from './api-requests.js';
+import { getShows, getLikes, postLike } from './api-requests.js';
 
 const displayShows = async () => {
   const data = await getShows('c');
@@ -38,5 +38,10 @@ const displayShows = async () => {
   });
   container.appendChild(fragment);
 };
+
+const updateLikes = async (id, element) => {
+  let likeCount = element.lastElementChild.textContent;
+  
+}
 
 export default displayShows;

--- a/src/modules/dom-manipulation.js
+++ b/src/modules/dom-manipulation.js
@@ -47,7 +47,6 @@ const updateLikes = async (id, element) => {
     likeCount += 1;
     element.lastElementChild.innerText = likeCount;
     heart.classList.add('fa-solid');
-    element.classList.add('disabled');
   }
 };
 


### PR DESCRIPTION
For this feature, the following changes were introduced: 
- When the page loads the number of likes for each item is requested to the involvement API and displayed below each corresponding like button
- Clicking on the like icon generates a POST request to the involvement API to register a new like for the given item and updates the displayed counter. For now, this event only triggers once

*Optional To-do:* The info about what items the user has liked is not registered in any way yet. After we finish the mandatory requirements let's try to persist this data with localStorage  👨‍💻 
